### PR TITLE
Add nix derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pc/jerry/lib
 engine.js.cstring
 game.js
 game.js.cstring
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,17 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation {
+	name = "spade";
+
+	src = lib.cleanSource ./.;
+	nativeBuildInputs = [cmake];
+	buildInputs = [
+		xorg.libX11
+		libGL
+		libxkbcommon
+	];
+
+	cmakeFlags = [ "--preset=pc" "-B ." ];
+
+	buildPhase = "make";
+	installPhase = "mkdir $out; mv spade $out/spade";
+}

--- a/pc/jerry/refresh.sh
+++ b/pc/jerry/refresh.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e
 
 cd ~/jerryscript_build


### PR DESCRIPTION
Flakes have trouble with submodules, so its a plain old default.nix.

Here's my attempt at a flake.nix if anyone wants to pick it up:

```nix
{
	inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
	
	outputs = { self, nixpkgs }: {
		defaultPackage.x86_64-linux =
			with import nixpkgs { system = "x86_64-linux"; };
			stdenv.mkDerivation {
				name = "spade";

				src = lib.cleanSource ./.;
				nativeBuildInputs = [cmake];
				buildInputs = [
					xorg.libX11
					libGL
					libxkbcommon
				];

				cmakeFlags = [ "--preset=pc" "-B ." ];

				buildPhase = "make";
				installPhase = "mkdir $out; mv spade $out/spade";
			};
	};
}
```