### PR TITLE
Define strlcat

### DIFF
--- a/jerryxx.c
+++ b/jerryxx.c
@@ -29,6 +29,41 @@
 
 #include "jerryscript.h"
 
+/*
+* Appends src to string dst of size siz (unlike strncat, siz is the
+* full size of dst, not space left).  At most siz-1 characters
+* will be copied.  Always NUL terminates (unless siz <= strlen(dst)).
+* Returns strlen(src) + MIN(siz, strlen(initial dst)).
+* If retval >= siz, truncation occurred.
+*/
+size_t
+strlcat(char *dst, const char *src, size_t siz)
+{
+	char *d = dst;
+	const char *s = src;
+	size_t n = siz;
+	size_t dlen;
+ 
+	/* Find the end of dst and adjust bytes left but don't go past end */
+	while (n-- != 0 && *d != '\0')
+		d++;
+	dlen = d - dst;
+	n = siz - dlen;
+ 
+	if (n == 0)
+		return(dlen + strlen(s));
+	while (*s != '\0') {
+		if (n != 1) {
+			*d++ = *s;
+			n--;
+		}
+		s++;
+	}
+	*d = '\0';
+ 
+	return(dlen + (s - src));	/* count does not include NUL */
+}
+
 void jerryxx_set_property(jerry_value_t object, const char *name,
                           jerry_value_t value) {
   jerry_value_t prop = jerry_create_string((const jerry_char_t *)name);


### PR DESCRIPTION
I'm not sure if or why this is required, but strlcat was missing when I tried to build spade, so I added a definition for it. Perhaps an include is missing somewhere?