### PR TITLE
Use location relative to script directory instead of home directory

### DIFF
--- a/pc/jerry/refresh.sh
+++ b/pc/jerry/refresh.sh
@@ -1,6 +1,9 @@
 set -e
 
-cd ~/jerryscript_build
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_HOME=$SCRIPT_DIR/../../..
+
+cd $PROJECT_HOME/jerryscript_build
 rm -rf example-*
 
 python3 jerryscript/tools/build.py \
@@ -16,7 +19,8 @@ python3 jerryscript/tools/build.py \
   --jerry-cmdline=OFF
 make -C $(pwd)/example_build install\
 
-cd ~/spade/pc/jerry
-cp -r ~/jerryscript_build/example_build/lib ./
+cd $PROJECT_HOME/spade/pc/jerry
+
+cp -r $PROJECT_HOME/jerryscript_build/example_build/lib ./
 rm -rf include
-cp -r ~/jerryscript_build/example_install/include ./
+cp -r $PROJECT_HOME/jerryscript_build/example_install/include ./


### PR DESCRIPTION
This makes `pc/jerry/refresh.sh` use directories relative to the script directory instead of the home directory.
This change is backwards compatible with the
```
~/spade
~/jerryscript_build
```
setup.