### PR TITLE
make instructions say to clone 1.3.1 branch of pico SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Download the Pico SDK:
 ```sh
 mkdir ~/raspberrypi
 cd ~/raspberrypi
-git clone https://github.com/raspberrypi/pico-sdk.git
+git clone -b 1.3.1 https://github.com/raspberrypi/pico-sdk.git
 git clone https://github.com/raspberrypi/pico-extras.git
 cd pico-sdk
 git submodule update --init


### PR DESCRIPTION
any branch after 1.3.1 causes an error saying `arm-none-eabi/bin/ld: region RAM overflowed` so until that can be solved this is the solution to compile spade for rpi