### PR TITLE
fix(text): warn about characters not supported in sprig engine

### DIFF
--- a/src/shared/sprig_engine/engine.js
+++ b/src/shared/sprig_engine/engine.js
@@ -50,7 +50,7 @@ exports.addText = (str, opts={}) => {
 
   for (const char of str.split('')) {
     if (" !\"#%&\'()*+,./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\^_-`abcdefghijklmnopqrstuvwxyz|~¦§¨©¬®¯°±´¶·¸ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ÙÚÛÜÝÞßàáâãäåæçèéêëìíîïñòóôõö÷ùúûüýþÿĀāĂăĄąĆćĊċČčĎĐđĒēĖėĘęĚěĞğĠġĦħĪīĮįİıŃńŇňŌōŒœŞşŨũŪūŮůŲųŴŵŶŷŸǍǎǏǐǑǒǓǔˆˇ˘˙˚˛˜˝ẀẁẂẃẄẅỲỳ†‡•…‰⁄™∂∅∏∑−√∞∫≈≠≤≥◊".indexOf(char) === -1)
-      throw new Error(`Character ${char} is not in the font. It will be rendered incorrectly.`)
+    console.log(`WARN: Character ${char} is no longer in supported in the Sprig editor.`);  
   }
 
   native.text_add(

--- a/src/shared/sprig_engine/engine.js
+++ b/src/shared/sprig_engine/engine.js
@@ -48,6 +48,11 @@ exports.addText = (str, opts={}) => {
   const CHARS_MAX_X = 21;
   const padLeft = Math.floor((CHARS_MAX_X - str.length)/2);
 
+  for (const char of str.split('')) {
+    if (" !\"#%&\'()*+,./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\^_-`abcdefghijklmnopqrstuvwxyz|~¦§¨©¬®¯°±´¶·¸ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ÙÚÛÜÝÞßàáâãäåæçèéêëìíîïñòóôõö÷ùúûüýþÿĀāĂăĄąĆćĊċČčĎĐđĒēĖėĘęĚěĞğĠġĦħĪīĮįİıŃńŇňŌōŒœŞşŨũŪūŮůŲųŴŵŶŷŸǍǎǏǐǑǒǓǔˆˇ˘˙˚˛˜˝ẀẁẂẃẄẅỲỳ†‡•…‰⁄™∂∅∏∑−√∞∫≈≠≤≥◊".indexOf(char) === -1)
+      throw new Error(`Character ${char} is not in the font. It will be rendered incorrectly.`)
+  }
+
   native.text_add(
     str,
     opts.color ?? [10, 10, 40],


### PR DESCRIPTION
will report an error if an unsupported character is encountered in the game code 

```
$ ./pc_build/src/spade game.js
bouta run some code
engine.js:afterInputs
couldn't run :(
err:
Error: Character $ is not in the font. It will be rendered incorrectly.
  at engine:53
  at game:51

[1]    65649 abort      ./pc_build/src/spade game.js
```