### PR TITLE
Delete docker/README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,0 @@
-# Building with Docker
- - Clone the repository with `--recursive`
- - Run the script in the root directory `build-with-docker.sh`
- - This script builds Spade from the sources in the parent directory.
-
-### Thank Yous
- - Random person on Github for explaining the correct packages to install to cross compile for ARM https://github.com/johnwalicki/RaspPi-Pico-Examples-Fedora


### PR DESCRIPTION
the README in the docker folder is a pitfall trap, and misdirects away from the main readme which contains the actual info required to build with docker. 